### PR TITLE
Follow uppercase convention for m_NumGuideVertices

### DIFF
--- a/src/TressFX/TressFXHairObject.cpp
+++ b/src/TressFX/TressFXHairObject.cpp
@@ -45,7 +45,7 @@ TressFXHairObject::TressFXHairObject(TressFXAsset* asset,
     EI_Device*   pDevice,
     EI_CommandContext&  commandContext,
     const char *      name, int RenderIndex) :
-    m_numGuideVertices(asset->m_numGuideVertices),
+    m_NumGuideVertices(asset->m_numGuideVertices),
     m_NumTotalVertices(0), 
     m_NumTotalStrands(0), 
     m_NumVerticesPerStrand(0), 

--- a/src/TressFX/TressFXHairObject.h
+++ b/src/TressFX/TressFXHairObject.h
@@ -111,7 +111,7 @@ public:
 
     TressFXDynamicState& GetDynamicState() { return m_DynamicState; }
 
-    int GetNumGuideHairVertices() const { return m_numGuideVertices; }
+    int GetNumGuideHairVertices() const { return m_NumGuideVertices; }
     int GetNumTotalHairVertices() const { return m_NumTotalVertices; }
     int GetNumTotalHairStrands() const { return m_NumTotalStrands; }
     int GetNumVerticesPerStrand() const { return m_NumVerticesPerStrand; }
@@ -121,7 +121,7 @@ public:
     EI_BindSet* GetRenderLayoutBindSet() const { return m_pRenderLayoutBindSet.get(); }
 
     // Get hair asset info
-    int GetNumGuideHairVertices() { return m_numGuideVertices; }
+    int GetNumGuideHairVertices() { return m_NumGuideVertices; }
     int GetNumTotalHairVertices() { return m_NumTotalVertices; }
     int GetNumTotalHairStrands() { return m_NumTotalStrands; }
     int GetNumVerticesPerStrand() { return m_NumVerticesPerStrand; }
@@ -143,7 +143,7 @@ private:
     void SetWind(const Vector3& windDir, float windMag, int frame);
 
     // hair asset information
-    int m_numGuideVertices;
+    int m_NumGuideVertices;
     int m_NumTotalVertices;
     int m_NumTotalStrands;
     int m_NumVerticesPerStrand;


### PR DESCRIPTION
... like the nearby member variables